### PR TITLE
TreeExtra runs only on Windows and Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 Additive Groves, Bagged Trees with Feature Evaluation, Interaction Detection, Visualization of Feature Effects
 
 This is a development version of the TreeExtra package. You can download the latest release directly from this repository (https://github.com/dariasor/TreeExtra/releases).
-You can find detailed manuals, early releases, related research papers and talks on http://additivegroves.net . 
+You can find detailed manuals, early releases, related research papers and talks on http://additivegroves.net. 
+
+TreeExtra is maintained for both Windows and Linux platforms. There is no support for OS X/macOS systems at this time.


### PR DESCRIPTION
Changed the README. 