### PR TITLE
fix Macro bug

### DIFF
--- a/AdditiveGroves/ag_expand.cpp
+++ b/AdditiveGroves/ag_expand.cpp
@@ -337,13 +337,19 @@ int main(int argc, char* argv[])
 						fstream*& pftemp = ftemps[tigNNo + prevAlphaN - 1 - alphaNo];
 						if(bagNo == 0)
 							pftemp = new fstream(tempFName.c_str(), ios_base::binary | ios_base::in);
-						if(pftemp->fail())
-							throw TEMP_ERR;		
-						
-						CGrove oldGrove(alpha, tigN);
-						oldGrove.load(*pftemp);
 
-						oldGrove.batchPredict(sinpreds[tigNNo], jointpreds[tigNNo]);
+                        // sometime when you train ag model with following parameters:
+                        //     > ./ag_train -a 0.01 -t data.train -v data.valid -r data.attr
+                        // program will suggest:
+                        //     > ./ag_train -a 0 -n 10 -b 100
+                        // In this case, AGTemp/ag.a.0.0.n.*.tmp may not created, so 
+                        // we should create this tmp file in current iteration
+						if(!pftemp->fail()) {
+                            CGrove oldGrove(alpha, tigN);
+                            oldGrove.load(*pftemp);
+
+                            oldGrove.batchPredict(sinpreds[tigNNo], jointpreds[tigNNo]);
+                        }
 
 						if(bagNo == prev.bagN - 1)
 						{

--- a/shared/definitions.h
+++ b/shared/definitions.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <limits>
 #include <stack>
+#include <math.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -108,7 +109,7 @@ enum AG_TRAIN_MODE
 
 #if defined(__VISUALC__)
     #define wxisNaN(n) _isnan(n)
-#elseif defined(__GNUC__)
+#elif defined(__GNUC__)
     #define wxisNaN(n) isnan(n)
 #else
     #define wxisNaN(n) ((n) != (n))


### PR DESCRIPTION
There is a typo in **definitions.h** file. After correct this typo, binary file build from a older g++ is also available.

``` shell
g++ (Ubuntu 4.3.3-5ubuntu4) 4.3.3
Copyright (C) 2008 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Two potential bugs:
+ bestPerf may used before initialized, so i set this variable to **NAN**, and assign to first perf no matter what the performance is
+ **ag_expand** still has potential error, when **ag_train** suggest to use smaller alpha then current used.