### PR TITLE
fix wrong counter of nodes

### DIFF
--- a/BaggedTrees/Tree.cpp
+++ b/BaggedTrees/Tree.cpp
@@ -45,7 +45,7 @@ public:
 		{
 			pJD->pNodes->push(nodeip(curNH.first->left, curNH.second + 1));
 			pJD->pNodes->push(nodeip(curNH.first->right, curNH.second + 1));
-			*pJD->pToDoN += 1;
+			*pJD->pToDoN += 2;
 
 			if(pAttrCounts)
 			{


### PR DESCRIPTION
When nodes are pushed to the stack, the counter of nodes should be increased by 2, not 1. Though, logic correctness is not affected.